### PR TITLE
Spring Security replaced by oauth2: login works correctly with jwt token

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,9 +55,8 @@
 		</dependency>
 
 		<dependency>
-			<groupId>org.springframework.security</groupId>
-			<artifactId>spring-security-test</artifactId>
-			<scope>test</scope>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.projectlombok</groupId>
@@ -79,7 +78,6 @@
 			</plugin>
 		</plugins>
 	</build>
-
 
 
 </project>

--- a/src/main/java/fr/dawan/portal_event/config/SpringSecurityConfig.java
+++ b/src/main/java/fr/dawan/portal_event/config/SpringSecurityConfig.java
@@ -1,0 +1,67 @@
+package fr.dawan.portal_event.config;
+
+import javax.crypto.spec.SecretKeySpec;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtEncoder;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+import org.springframework.security.oauth2.jwt.NimbusJwtEncoder;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+import org.springframework.security.web.SecurityFilterChain;
+
+import com.nimbusds.jose.jwk.source.ImmutableSecret;
+
+@Configuration
+public class SpringSecurityConfig {
+
+
+	
+	@Bean
+	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {		
+		return http
+				.csrf(csrf -> csrf.disable())
+				.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+				.authorizeHttpRequests(auth -> auth.anyRequest().authenticated())
+				.httpBasic(Customizer.withDefaults())
+                .oauth2ResourceServer((oauth2) -> oauth2.jwt(Customizer.withDefaults()))
+				.build();		
+	}
+	
+	@Bean
+	public UserDetailsService users() {
+		UserDetails user = User.builder().username("user").password(passwordEncoder().encode("password")).roles("USER")
+				.build();		
+		return new InMemoryUserDetailsManager(user);
+	}
+
+
+	@Bean
+	public BCryptPasswordEncoder passwordEncoder() {
+		return new BCryptPasswordEncoder();
+	}
+
+    @Bean
+	public JwtEncoder jwtEncoder() {
+		return new NimbusJwtEncoder(new ImmutableSecret<>(this.jwtKey.getBytes()));
+	}
+
+
+    private String jwtKey = "B3ayAnStKJtSHPZqdNF0SNPFMF7uU5Q8";
+    @Bean
+    public JwtDecoder jwtDecoder() {
+        SecretKeySpec secretKey = new SecretKeySpec(this.jwtKey.getBytes(), 0, this.jwtKey.getBytes().length,"RSA");
+        return NimbusJwtDecoder.withSecretKey(secretKey).macAlgorithm(MacAlgorithm.HS256).build();
+    }
+
+
+}

--- a/src/main/java/fr/dawan/portal_event/controllers/AuthController.java
+++ b/src/main/java/fr/dawan/portal_event/controllers/AuthController.java
@@ -1,0 +1,23 @@
+package fr.dawan.portal_event.controllers;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import fr.dawan.portal_event.services.JwtService;
+
+@RestController
+public class AuthController {
+
+    private JwtService jwtService;
+
+    public AuthController(JwtService jwtService){
+        this.jwtService = jwtService;
+    }
+
+    @PostMapping("/login")
+    public String getToken(Authentication authentication){
+        String token = jwtService.generateToken(authentication);
+        return token;
+    }
+}

--- a/src/main/java/fr/dawan/portal_event/services/JwtService.java
+++ b/src/main/java/fr/dawan/portal_event/services/JwtService.java
@@ -1,0 +1,36 @@
+package fr.dawan.portal_event.services;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
+import org.springframework.security.oauth2.jwt.JwsHeader;
+import org.springframework.security.oauth2.jwt.JwtClaimsSet;
+import org.springframework.security.oauth2.jwt.JwtEncoder;
+import org.springframework.security.oauth2.jwt.JwtEncoderParameters;
+import org.springframework.stereotype.Service;
+
+@Service
+public class JwtService {
+    private JwtEncoder jwtEncoder;
+
+    public JwtService(JwtEncoder jwtEncoder){
+        this.jwtEncoder = jwtEncoder;
+    }
+
+    public String generateToken(Authentication authentication){
+        Instant now = Instant.now();
+
+        JwtClaimsSet claims = JwtClaimsSet.builder()
+        .issuer("self")
+        .issuedAt(now)
+        .expiresAt(now.plus(1, ChronoUnit.DAYS))
+        .subject(authentication.getName())
+        .build();
+
+        JwtEncoderParameters jwtEncoderParameters = JwtEncoderParameters.from(JwsHeader.with(MacAlgorithm.HS256).build(), claims);
+
+        return this.jwtEncoder.encode(jwtEncoderParameters).getTokenValue();
+    }
+}

--- a/src/main/java/fr/dawan/portal_event/utils/JwtTokenProvider.java
+++ b/src/main/java/fr/dawan/portal_event/utils/JwtTokenProvider.java
@@ -1,0 +1,8 @@
+package fr.dawan.portal_event.utils;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtTokenProvider {
+
+}


### PR DESCRIPTION
### Main Change: 
Replaced Spring Security with OAuth2 for authentication management.
### Justification:
OAuth2 integrates with Spring Security and provides a more robust and standardized authentication mechanism for APIs.
A user account with credentials "user" and "password" is created locally during the development phase to facilitate authentication testing.
Support for generating a JWT token (JSON Web Token) is now implemented, enabling secure and stateless session management.
### Impact:
This part of the development is essential to properly test API requests, ensuring optimal security during interactions with the application.